### PR TITLE
Improved functionality in ScrollView, solved issue with ContextWrapper

### DIFF
--- a/searchablespinnerlibrary/src/main/java/com/toptoche/searchablespinnerlibrary/SearchableSpinner.java
+++ b/searchablespinnerlibrary/src/main/java/com/toptoche/searchablespinnerlibrary/SearchableSpinner.java
@@ -2,6 +2,7 @@ package com.toptoche.searchablespinnerlibrary;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.ContextWrapper;
 import android.content.DialogInterface;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
@@ -47,7 +48,7 @@ public class SearchableSpinner extends Spinner implements View.OnTouchListener,
 
     @Override
     public boolean onTouch(View v, MotionEvent event) {
-        if (event.getAction() == MotionEvent.ACTION_DOWN) {
+        if (event.getAction() == MotionEvent.ACTION_UP) {
             ArrayAdapter adapter = (ArrayAdapter) getAdapter();
 
             if (null != adapter) {
@@ -58,7 +59,7 @@ public class SearchableSpinner extends Spinner implements View.OnTouchListener,
                     }
                 }
 
-                _searchableListDialog.show(((Activity) _context).getFragmentManager(), "TAG");
+                _searchableListDialog.show(scanForActivity(_context).getFragmentManager(), "TAG");
             }
         }
         return true;
@@ -79,5 +80,16 @@ public class SearchableSpinner extends Spinner implements View.OnTouchListener,
 
     public void setPositiveButton(String strPositiveButtonText, DialogInterface.OnClickListener onClickListener) {
         _searchableListDialog.setPositiveButton(strPositiveButtonText, onClickListener);
+    }
+
+    private Activity scanForActivity(Context cont) {
+        if (cont == null)
+            return null;
+        else if (cont instanceof Activity)
+            return (Activity)cont;
+        else if (cont instanceof ContextWrapper)
+            return scanForActivity(((ContextWrapper)cont).getBaseContext());
+
+        return null;
     }
 }


### PR DESCRIPTION
When the Spinner is used in a ScrollView the **MotionEvent.ACTION_DOWN** is not very suitable, it is better to use **MotionEvent.ACTION_UP**.

In addition, to avoid exceptions with **ContextWrapper** I added a method to get the activity.

References: http://stackoverflow.com/questions/13129428/accessing-activity-from-custom-button/27434704#27434704