### PR TITLE
Support spinner adapters

### DIFF
--- a/searchablespinnerlibrary/src/main/java/com/toptoche/searchablespinnerlibrary/SearchableSpinner.java
+++ b/searchablespinnerlibrary/src/main/java/com/toptoche/searchablespinnerlibrary/SearchableSpinner.java
@@ -25,7 +25,7 @@ public class SearchableSpinner extends Spinner implements View.OnTouchListener,
     private SearchableListDialog _searchableListDialog;
 
     private boolean _isDirty;
-    private ArrayAdapter _arrayAdapter;
+    private SpinnerAdapter _arrayAdapter;
     private String _strHintText;
     private boolean _isFromInit;
 
@@ -63,7 +63,7 @@ public class SearchableSpinner extends Spinner implements View.OnTouchListener,
         _searchableListDialog.setOnSearchableItemClickListener(this);
         setOnTouchListener(this);
 
-        _arrayAdapter = (ArrayAdapter) getAdapter();
+        _arrayAdapter = getAdapter();
         if (!TextUtils.isEmpty(_strHintText)) {
             ArrayAdapter arrayAdapter = new ArrayAdapter(_context, android.R.layout
                     .simple_list_item_1, new String[]{_strHintText});
@@ -98,7 +98,7 @@ public class SearchableSpinner extends Spinner implements View.OnTouchListener,
     public void setAdapter(SpinnerAdapter adapter) {
 
         if (!_isFromInit) {
-            _arrayAdapter = (ArrayAdapter) adapter;
+            _arrayAdapter = adapter;
             if (!TextUtils.isEmpty(_strHintText) && !_isDirty) {
                 ArrayAdapter arrayAdapter = new ArrayAdapter(_context, android.R.layout
                         .simple_list_item_1, new String[]{_strHintText});


### PR DESCRIPTION
Currently, library supports only array adapters which is absolutely incorrect. 

``` java
Caused by: java.lang.ClassCastException: 
my.custom.adapter.NewSpinnerAdapter cannot be cast to android.widget.ArrayAdapter at 
com.toptoche.searchablespinnerlibrary.SearchableSpinner.setAdapter(SearchableSpinner.java:101)
```
