### PR TITLE
Added adapter factory for customize the list view elements in the dialog

### DIFF
--- a/searchablespinnerlibrary/src/main/java/com/toptoche/searchablespinnerlibrary/SearchableListDialog.java
+++ b/searchablespinnerlibrary/src/main/java/com/toptoche/searchablespinnerlibrary/SearchableListDialog.java
@@ -32,6 +32,8 @@ public class SearchableListDialog extends DialogFragment implements
 
     private SearchableItem _searchableItem;
 
+    private AdapterFactory _adapterFactory;
+
     private OnSearchTextChanged _onSearchTextChanged;
 
     private SearchView _searchView;
@@ -157,8 +159,12 @@ public class SearchableListDialog extends DialogFragment implements
         _listViewItems = (ListView) rootView.findViewById(R.id.listItems);
 
         //create the adapter by passing your ArrayList data
-        listAdapter = new ArrayAdapter(getActivity(), android.R.layout.simple_list_item_1,
-                items);
+        if(_adapterFactory != null){
+            listAdapter = _adapterFactory.newInstance(items);
+        }else {
+            listAdapter = new ArrayAdapter(getActivity(), android.R.layout.simple_list_item_1,
+                    items);
+        }
         //attach the adapter to the list
         _listViewItems.setAdapter(listAdapter);
 
@@ -199,11 +205,19 @@ public class SearchableListDialog extends DialogFragment implements
         return true;
     }
 
+    public void setAdapterFactoty(AdapterFactory adapterFactoty){
+        this._adapterFactory = adapterFactoty;
+    }
+
     public interface SearchableItem<T> extends Serializable {
         void onSearchableItemClicked(T item, int position);
     }
 
     public interface OnSearchTextChanged {
         void onSearchTextChanged(String strText);
+    }
+
+    public interface AdapterFactory{
+        public ArrayAdapter newInstance(List items);
     }
 }

--- a/searchablespinnerlibrary/src/main/java/com/toptoche/searchablespinnerlibrary/SearchableSpinner.java
+++ b/searchablespinnerlibrary/src/main/java/com/toptoche/searchablespinnerlibrary/SearchableSpinner.java
@@ -168,4 +168,11 @@ public class SearchableSpinner extends Spinner implements View.OnTouchListener,
             return super.getSelectedItem();
         }
     }
+
+
+    public void setDialogAdapterFactory(SearchableListDialog.AdapterFactory adapterFactory){
+        if(_searchableListDialog != null){
+            _searchableListDialog.setAdapterFactoty(adapterFactory);
+        }
+    }
 }


### PR DESCRIPTION
When you declare and configure the searchable spinner, can specify how instantiate the adpter for list view in the dialog. Below an example:

mSpinner.setDialogAdapterFactory(new SearchableListDialog.AdapterFactory() {
                @Override
                public ArrayAdapter newInstance(List list) {
                    return new MyCustomArrayAdapter(getContext(),list);
                }
            });