### PR TITLE
Update SearchableSpinner.java

### DIFF
--- a/searchablespinnerlibrary/src/main/java/com/toptoche/searchablespinnerlibrary/SearchableSpinner.java
+++ b/searchablespinnerlibrary/src/main/java/com/toptoche/searchablespinnerlibrary/SearchableSpinner.java
@@ -74,6 +74,9 @@ public class SearchableSpinner extends Spinner implements View.OnTouchListener,
 
     @Override
     public boolean onTouch(View v, MotionEvent event) {
+        if (_searchableListDialog.isAdded()) {
+            return true;
+        }
         if (event.getAction() == MotionEvent.ACTION_UP) {
 
             if (null != _arrayAdapter) {


### PR DESCRIPTION
Fix issue where a delayed display of dialog by the fragment manager would result in IllegalStateException where spinner is tapped more than once whilst waiting for the dialog to appear.